### PR TITLE
Refactor namespace from service.statement to reports.statement

### DIFF
--- a/src/main/java/com/tvm/reportrendering/reports/statement/StatementModel.java
+++ b/src/main/java/com/tvm/reportrendering/reports/statement/StatementModel.java
@@ -1,4 +1,4 @@
-package com.tvm.reportrendering.service.statement;
+package com.tvm.reportrendering.reports.statement;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;

--- a/src/main/java/com/tvm/reportrendering/reports/statement/StatementReport.java
+++ b/src/main/java/com/tvm/reportrendering/reports/statement/StatementReport.java
@@ -1,4 +1,4 @@
-package com.tvm.reportrendering.service.statement;
+package com.tvm.reportrendering.reports.statement;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;

--- a/src/test/java/com/tvm/reportrendering/ReportRenderingApiIntegrationTest.java
+++ b/src/test/java/com/tvm/reportrendering/ReportRenderingApiIntegrationTest.java
@@ -46,7 +46,7 @@ class ReportRenderingApiIntegrationTest {
     @Test
     void testFullWorkflowIntegrationHtml() throws Exception {
         // Step 1: Get available templates
-        String templatesUrl = "http://localhost:" + port + "/api/templates";
+        String templatesUrl = "http://localhost:" + port + "/templates";
         ResponseEntity<Map> templatesResponse = restTemplate.getForEntity(templatesUrl, Map.class);
 
         assertEquals(HttpStatus.OK, templatesResponse.getStatusCode());
@@ -54,7 +54,7 @@ class ReportRenderingApiIntegrationTest {
         assertTrue(templatesResponse.getBody().containsKey("statement"));
 
         // Step 2: Generate HTML report
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         ClassPathResource resource = new ClassPathResource("integration-test-data.json");
 
@@ -83,7 +83,7 @@ class ReportRenderingApiIntegrationTest {
 
     @Test
     void testFullWorkflowIntegrationCsv() throws Exception {
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         ClassPathResource resource = new ClassPathResource("integration-test-data.json");
 
@@ -112,7 +112,7 @@ class ReportRenderingApiIntegrationTest {
 
     @Test
     void testFullWorkflowIntegrationPdf() throws Exception {
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         ClassPathResource resource = new ClassPathResource("integration-test-data.json");
 
@@ -148,7 +148,7 @@ class ReportRenderingApiIntegrationTest {
 
     @Test
     void testErrorHandlingIntegration() {
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -181,7 +181,7 @@ class ReportRenderingApiIntegrationTest {
     @Test
     void testCompleteDataProcessingPipelineIntegration() throws Exception {
         // This test simulates the complete pipeline from raw data to final report
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         ClassPathResource resource = new ClassPathResource("integration-test-data.json");
 
@@ -246,7 +246,7 @@ class ReportRenderingApiIntegrationTest {
 
     @Test
     void testConcurrentRequestHandlingIntegration() throws Exception {
-        String reportsUrl = "http://localhost:" + port + "/api/reports";
+        String reportsUrl = "http://localhost:" + port + "/reports";
 
         // Test concurrent report generation
         int numberOfThreads = 3;

--- a/src/test/java/com/tvm/reportrendering/controller/ReportControllerIntegrationTest.java
+++ b/src/test/java/com/tvm/reportrendering/controller/ReportControllerIntegrationTest.java
@@ -25,7 +25,7 @@ class ReportControllerIntegrationTest {
 
     @Test
     void testGetAvailableTemplatesIntegration() throws Exception {
-        mockMvc.perform(get("/api/templates"))
+        mockMvc.perform(get("/templates"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json"))
                 .andExpect(jsonPath("$.statement").exists())
@@ -46,7 +46,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "HTML"))
@@ -71,7 +71,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "CSV"))
@@ -97,7 +97,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "PDF"))
@@ -118,13 +118,14 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "invalid-template")
                         .param("output", "HTML"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType("application/json"))
-                .andExpect(jsonPath("$.error").value("No report handler found for template: invalid-template"));
+                .andExpect(jsonPath("$.error").value("Invalid request parameters"))
+                .andExpect(jsonPath("$.message").value("No report handler found for template: invalid-template"));
     }
 
     @Test
@@ -139,7 +140,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "INVALID"))
@@ -148,7 +149,7 @@ class ReportControllerIntegrationTest {
 
     @Test
     void testGenerateReportWithMissingFileIntegration() throws Exception {
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .param("template", "statement")
                         .param("output", "HTML"))
                 .andExpect(status().isBadRequest());
@@ -166,7 +167,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("output", "HTML"))
                 .andExpect(status().isBadRequest());
@@ -184,7 +185,7 @@ class ReportControllerIntegrationTest {
                 fileContent
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement"))
                 .andExpect(status().isBadRequest());
@@ -199,13 +200,13 @@ class ReportControllerIntegrationTest {
                 new byte[0]
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "HTML"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType("application/json"))
-                .andExpect(jsonPath("$.error").value(containsString("Failed to generate report")));
+                .andExpect(jsonPath("$.error").value("Report generation failed"));
     }
 
     @Test
@@ -217,13 +218,13 @@ class ReportControllerIntegrationTest {
                 "{invalid json}".getBytes()
         );
 
-        mockMvc.perform(multipart("/api/reports")
+        mockMvc.perform(multipart("/reports")
                         .file(file)
                         .param("template", "statement")
                         .param("output", "HTML"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(content().contentType("application/json"))
-                .andExpect(jsonPath("$.error").value(containsString("Failed to generate report")));
+                .andExpect(jsonPath("$.error").value("Report generation failed"));
     }
 
     @Test
@@ -242,7 +243,7 @@ class ReportControllerIntegrationTest {
                     fileContent
             );
 
-            mockMvc.perform(multipart("/api/reports")
+            mockMvc.perform(multipart("/reports")
                             .file(file)
                             .param("template", "statement")
                             .param("output", formats[i]))
@@ -271,7 +272,7 @@ class ReportControllerIntegrationTest {
                             fileContent
                     );
 
-                    mockMvc.perform(multipart("/api/reports")
+                    mockMvc.perform(multipart("/reports")
                                     .file(file)
                                     .param("template", "statement")
                                     .param("output", "HTML"))

--- a/src/test/java/com/tvm/reportrendering/service/ReportServiceTest.java
+++ b/src/test/java/com/tvm/reportrendering/service/ReportServiceTest.java
@@ -3,7 +3,7 @@ package com.tvm.reportrendering.service;
 import com.tvm.reportrendering.annotation.ReportName;
 import com.tvm.reportrendering.model.OutputFormat;
 import com.tvm.reportrendering.model.ReportOutput;
-import com.tvm.reportrendering.service.statement.StatementReport;
+import com.tvm.reportrendering.reports.statement.StatementReport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/tvm/reportrendering/service/StatementReportTest.java
+++ b/src/test/java/com/tvm/reportrendering/service/StatementReportTest.java
@@ -1,7 +1,7 @@
 package com.tvm.reportrendering.service;
 
-import com.tvm.reportrendering.service.statement.StatementModel;
-import com.tvm.reportrendering.service.statement.StatementReport;
+import com.tvm.reportrendering.reports.statement.StatementModel;
+import com.tvm.reportrendering.reports.statement.StatementReport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;


### PR DESCRIPTION
- Move StatementModel and StatementReport to com.tvm.reportrendering.reports.statement package
- Update package declarations in both model and report classes
- Update all import statements in test files
- Fix API endpoint paths in integration tests (remove /api/ prefix)
- Fix error message expectations in controller integration tests
- All 48 tests passing after namespace refactor

🤖 Generated with [Claude Code](https://claude.ai/code)