### PR TITLE
Fix Dockerfile with multi-stage build and Playwright base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,94 +1,74 @@
-# Use Red Hat Enterprise Linux 9 as base image
-FROM registry.access.redhat.com/ubi9/ubi:latest
+
+
+# ---- Build Stage ----
+FROM openjdk:17-slim AS build
+
+WORKDIR /app
+
+# Install Maven
+RUN apt-get update && \
+    apt-get install -y maven && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy pom.xml and download dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source code and build
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# ---- Runtime Stage ----
+FROM mcr.microsoft.com/playwright:v1.50.0-noble
 
 # Set maintainer label
 LABEL maintainer="igormusic@tvmsoftware.com"
 LABEL description="Spring Boot Report Rendering API with Playwright"
 
-# Install required packages
-RUN dnf update -y && \
-    dnf install -y \
-    java-17-openjdk-devel \
-    maven \
-    wget \
-    curl \
-    ca-certificates \
-    fontconfig \
-    libX11 \
-    libXcomposite \
-    libXdamage \
-    libXext \
-    libXfixes \
-    libXrandr \
-    libXrender \
-    libXtst \
-    libxcb \
-    libxshmfence \
-    libnss3 \
-    libdrm \
-    libxkbcommon \
-    libatspi \
-    libgtk-3 \
-    alsa-lib && \
-    dnf clean all
+
+
+# Install minimal Java runtime
+USER root
+RUN apt-get update && \
+    apt-get install -y openjdk-17-jre && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set JAVA_HOME
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV PATH="$JAVA_HOME/bin:$PATH"
+
 
 # Create application directory
 WORKDIR /app
 
-# Copy Maven wrapper and pom.xml first for better layer caching
-COPY mvnw .
-COPY .mvn .mvn
-COPY pom.xml .
+# Copy built jar from build stage
+COPY --from=build /app/target/report-rendering-api-*.jar ./target/
 
-# Make Maven wrapper executable
-RUN chmod +x ./mvnw
 
-# Download dependencies
-RUN ./mvnw dependency:go-offline -B
 
-# Copy source code
-COPY src ./src
+# Set permissions for pwuser (default Playwright user)
+RUN mkdir -p /app/logs && \
+    chown -R pwuser:pwuser /app
 
-# Build the application
-RUN ./mvnw clean package -DskipTests
+USER pwuser
 
-# Install Node.js (required for Playwright)
-RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
-    dnf install -y nodejs
 
-# Create a non-root user for security
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-# Create directories and set permissions
-RUN mkdir -p /app/logs /app/playwright && \
-    chown -R appuser:appuser /app
-
-# Switch to non-root user
-USER appuser
-
-# Install Playwright and Chromium
-RUN npm init -y && \
-    npm install playwright@latest && \
-    npx playwright install chromium && \
-    npx playwright install-deps chromium
-
-# Set environment variables for Playwright
-ENV PLAYWRIGHT_BROWSERS_PATH=/app/playwright
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=false
 
 # Expose port
 EXPOSE 8080
 
+
+
 # Set JVM options for container environment
 ENV JAVA_OPTS="-Xmx512m -Xms256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
 
+
+
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8080/templates || exit 1
+    CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+
 
 # Run the application
 CMD ["sh", "-c", "java $JAVA_OPTS -jar target/report-rendering-api-*.jar"]


### PR DESCRIPTION
- Replace RHEL base with openjdk:17-slim for build stage
- Use mcr.microsoft.com/playwright:v1.50.0-noble for runtime
- Eliminate manual Node.js and Playwright installation
- Use pwuser instead of custom user creation
- Fix health check endpoint to /actuator/health
- Reduce image complexity and build time

🤖 Generated with [Claude Code](https://claude.ai/code)