### PR TITLE
Refactor to use centralized SecurityUtils.sanitizeForLogging function

### DIFF
--- a/src/main/java/com/tvm/reportrendering/controller/ReportController.java
+++ b/src/main/java/com/tvm/reportrendering/controller/ReportController.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static com.tvm.reportrendering.util.SecurityUtils.sanitizeForLogging;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -32,12 +34,6 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    private String sanitizeForLogging(String input) {
-        if (input == null) {
-            return "null";
-        }
-        return input.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-    }
 
     @Operation(
             summary = "Generate a financial report",

--- a/src/main/java/com/tvm/reportrendering/reports/statement/StatementReport.java
+++ b/src/main/java/com/tvm/reportrendering/reports/statement/StatementReport.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Comparator;
 
+import static com.tvm.reportrendering.util.SecurityUtils.sanitizeForLogging;
+
 @Slf4j
 @Component
 @ReportName("statement")
@@ -18,12 +20,6 @@ public class StatementReport extends Report<StatementModel> {
 
     private final ObjectMapper objectMapper;
 
-    private String sanitizeForLogging(String input) {
-        if (input == null) {
-            return "null";
-        }
-        return input.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-    }
 
     public StatementReport() {
         this.objectMapper = new ObjectMapper();

--- a/src/main/java/com/tvm/reportrendering/service/Report.java
+++ b/src/main/java/com/tvm/reportrendering/service/Report.java
@@ -12,6 +12,8 @@ import org.thymeleaf.context.Context;
 import java.io.InputStream;
 import java.util.Map;
 
+import static com.tvm.reportrendering.util.SecurityUtils.sanitizeForLogging;
+
 @Slf4j
 public abstract class Report<T> {
 
@@ -23,12 +25,6 @@ public abstract class Report<T> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private String sanitizeForLogging(String input) {
-        if (input == null) {
-            return "null";
-        }
-        return input.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-    }
 
     public ReportOutput process(InputStream inputStream, String templateName, OutputFormat outputFormat, String language) {
         log.info("Processing report with template: {}, format: {} and language: {}", sanitizeForLogging(templateName), outputFormat, sanitizeForLogging(language));

--- a/src/main/java/com/tvm/reportrendering/service/ReportService.java
+++ b/src/main/java/com/tvm/reportrendering/service/ReportService.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.tvm.reportrendering.util.SecurityUtils.sanitizeForLogging;
+
 @Slf4j
 @Service
 public class ReportService {
@@ -24,12 +26,6 @@ public class ReportService {
 
     private Map<String, Report<?>> reportHandlers = new HashMap<>();
 
-    private String sanitizeForLogging(String input) {
-        if (input == null) {
-            return "null";
-        }
-        return input.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-    }
 
     @PostConstruct
     public void initializeReportHandlers() {

--- a/src/main/java/com/tvm/reportrendering/util/SecurityUtils.java
+++ b/src/main/java/com/tvm/reportrendering/util/SecurityUtils.java
@@ -1,0 +1,31 @@
+package com.tvm.reportrendering.util;
+
+/**
+ * Security utility class providing common security-related functions.
+ *
+ * This class contains methods to help prevent security vulnerabilities
+ * such as log injection attacks.
+ */
+public class SecurityUtils {
+
+    /**
+     * Sanitizes input strings for safe logging by replacing potentially
+     * dangerous characters that could be used for log injection attacks.
+     *
+     * This method removes or replaces:
+     * - Carriage return (\r) → underscore (_)
+     * - Line feed/newline (\n) → underscore (_)
+     * - Tab character (\t) → underscore (_)
+     *
+     * @param input the input string to sanitize, may be null
+     * @return sanitized string safe for logging, "null" if input is null
+     */
+    public static String sanitizeForLogging(String input) {
+        if (input == null) {
+            return "null";
+        }
+        return input.replace('\r', '_')
+                   .replace('\n', '_')
+                   .replace('\t', '_');
+    }
+}

--- a/src/main/resources/alerts.json
+++ b/src/main/resources/alerts.json
@@ -1,0 +1,1574 @@
+[
+  {
+    "number": 49,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/49",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/49",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/ReportService.java",
+        "start_line": 46,
+        "end_line": 46,
+        "start_column": 9,
+        "end_column": 126
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/49/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 48,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/48",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/48",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 27,
+        "end_line": 27,
+        "start_column": 9,
+        "end_column": 123
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/48/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 47,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/47",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/47",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value.\nThis log entry depends on a user-provided value.\nThis log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/controller/ReportController.java",
+        "start_line": 63,
+        "end_line": 64,
+        "start_column": 9,
+        "end_column": 72
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/47/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 46,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/46",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/46",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 58,
+        "end_line": 58,
+        "start_column": 61,
+        "end_column": 77
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/46/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 45,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/45",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/45",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 55,
+        "end_line": 55,
+        "start_column": 52,
+        "end_column": 68
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/45/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 44,
+    "created_at": "2025-09-16T21:24:22Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/44",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/44",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/controller/ReportController.java",
+        "start_line": 68,
+        "end_line": 68,
+        "start_column": 52,
+        "end_column": 60
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/44/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 43,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/43",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/43",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/reports/statement/StatementReport.java",
+        "start_line": 92,
+        "end_line": 93,
+        "start_column": 9,
+        "end_column": 102
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/43/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 42,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/42",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/42",
+    "assignees": [
+
+    ],
+    "state": "fixed",
+    "fixed_at": "2025-09-16T21:24:37Z",
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "fixed",
+      "commit_sha": "89fb6a963c5e9d7252f5563390ad1a2534f5a46f",
+      "message": {
+        "text": "This log entry depends on a user-provided value.\nThis log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/controller/ReportController.java",
+        "start_line": 61,
+        "end_line": 62,
+        "start_column": 9,
+        "end_column": 62
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/42/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 41,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/41",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/41",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/ReportService.java",
+        "start_line": 50,
+        "end_line": 50,
+        "start_column": 67,
+        "end_column": 79
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/41/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 40,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/40",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/40",
+    "assignees": [
+
+    ],
+    "state": "fixed",
+    "fixed_at": "2025-09-16T21:24:37Z",
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "fixed",
+      "commit_sha": "89fb6a963c5e9d7252f5563390ad1a2534f5a46f",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/ReportService.java",
+        "start_line": 46,
+        "end_line": 46,
+        "start_column": 72,
+        "end_column": 84
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/40/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 39,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/39",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/39",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 110,
+        "end_line": 110,
+        "start_column": 58,
+        "end_column": 70
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/39/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 38,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/38",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/38",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 104,
+        "end_line": 104,
+        "start_column": 58,
+        "end_column": 70
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/38/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 37,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T21:24:37Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/37",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/37",
+    "assignees": [
+
+    ],
+    "state": "fixed",
+    "fixed_at": "2025-09-16T21:24:37Z",
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/log-injection",
+      "severity": "error",
+      "description": "Log Injection",
+      "name": "java/log-injection",
+      "tags": ["external/cwe/cwe-117","security"],
+      "full_description": "Building log entries from user-controlled data may allow insertion of forged log entries by malicious users.",
+      "help": "# Log Injection\nIf unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.\n\nForgery can occur if a user provides some input creating the appearance of multiple log entries. This can include unescaped new-line characters, or HTML or other markup.\n\n\n## Recommendation\nUser input should be suitably sanitized before it is logged.\n\nIf the log entries are plain text then line breaks should be removed from user input, using for example `String replace(char oldChar, char newChar)` or similar. Care should also be taken that user input is clearly marked in log entries, and that a malicious user cannot cause confusion in other ways.\n\nFor log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and other forms of HTML injection.\n\n\n## Example\nIn the first example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). In the first case (`/bad` endpoint), the username is logged without any sanitization. If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, the log entry will be split into two separate lines, where the first line will be `User:'Guest'` and the second one will be `User:'Admin'`.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /bad?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/bad\")\n    public String bad(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        log.warn(\"User:'{}'\", username);\n        // The logging call above would result in multiple log entries as shown below:\n        // User:'Guest'\n        // User:'Admin'\n        return username;\n    }\n}\n\n\n```\nIn the second example (`/good` endpoint), `matches()` is used to ensure the user input only has alphanumeric characters. If a malicious user provides \\`Guest'%0AUser:'Admin\\` as a username parameter, the log entry will not be logged at all, preventing the injection.\n\n\n```java\npackage com.example.restservice;\n\nimport org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;\nimport org.springframework.web.bind.annotation.GetMapping;\nimport org.springframework.web.bind.annotation.RequestParam;\nimport org.springframework.web.bind.annotation.RestController;\n\n@RestController\npublic class LogInjection {\n\n    private final Logger log = LoggerFactory.getLogger(LogInjection.class);\n\n    // /good?username=Guest'%0AUser:'Admin\n    @GetMapping(\"/good\")\n    public String good(@RequestParam(value = \"username\", defaultValue = \"name\") String username) {\n        // The regex check here, allows only alphanumeric characters to pass.\n        // Hence, does not result in log injection\n        if (username.matches(\"\\\\w*\")) {\n            log.warn(\"User:'{}'\", username);\n\n            return username;\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Log Injection](https://owasp.org/www-community/attacks/Log_Injection).\n* Common Weakness Enumeration: [CWE-117](https://cwe.mitre.org/data/definitions/117.html).\n",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "fixed",
+      "commit_sha": "89fb6a963c5e9d7252f5563390ad1a2534f5a46f",
+      "message": {
+        "text": "This log entry depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 22,
+        "end_line": 22,
+        "start_column": 72,
+        "end_column": 84
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/37/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 36,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/36",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/36",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/server-side-template-injection",
+      "severity": "error",
+      "description": "Server-side template injection",
+      "name": "java/server-side-template-injection",
+      "tags": ["external/cwe/cwe-094","external/cwe/cwe-1336","security"],
+      "full_description": "Untrusted input interpreted as a template can lead to remote code execution.",
+      "help": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\t// BAD: code is controlled by the user\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s); // GOOD: s is a constant string\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+      "security_severity_level": "critical"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Template, which may contain code, depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 108,
+        "end_line": 108,
+        "start_column": 52,
+        "end_column": 80
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/36/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 35,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/35",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/35",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/server-side-template-injection",
+      "severity": "error",
+      "description": "Server-side template injection",
+      "name": "java/server-side-template-injection",
+      "tags": ["external/cwe/cwe-094","external/cwe/cwe-1336","security"],
+      "full_description": "Untrusted input interpreted as a template can lead to remote code execution.",
+      "help": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\t// BAD: code is controlled by the user\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s); // GOOD: s is a constant string\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+      "security_severity_level": "critical"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Template, which may contain code, depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 102,
+        "end_line": 102,
+        "start_column": 52,
+        "end_column": 80
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/35/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 34,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/34",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/34",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/server-side-template-injection",
+      "severity": "error",
+      "description": "Server-side template injection",
+      "name": "java/server-side-template-injection",
+      "tags": ["external/cwe/cwe-094","external/cwe/cwe-1336","security"],
+      "full_description": "Untrusted input interpreted as a template can lead to remote code execution.",
+      "help": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\t// BAD: code is controlled by the user\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s); // GOOD: s is a constant string\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+      "security_severity_level": "critical"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Template, which may contain code, depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 95,
+        "end_line": 95,
+        "start_column": 53,
+        "end_column": 74
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/34/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 33,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/33",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/33",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/server-side-template-injection",
+      "severity": "error",
+      "description": "Server-side template injection",
+      "name": "java/server-side-template-injection",
+      "tags": ["external/cwe/cwe-094","external/cwe/cwe-1336","security"],
+      "full_description": "Untrusted input interpreted as a template can lead to remote code execution.",
+      "help": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\t// BAD: code is controlled by the user\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s); // GOOD: s is a constant string\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+      "security_severity_level": "critical"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Template, which may contain code, depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 90,
+        "end_line": 90,
+        "start_column": 49,
+        "end_column": 61
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/33/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 32,
+    "created_at": "2025-09-16T12:54:11Z",
+    "updated_at": "2025-09-16T12:54:11Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/32",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/32",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "java/server-side-template-injection",
+      "severity": "error",
+      "description": "Server-side template injection",
+      "name": "java/server-side-template-injection",
+      "tags": ["external/cwe/cwe-094","external/cwe/cwe-1336","security"],
+      "full_description": "Untrusted input interpreted as a template can lead to remote code execution.",
+      "help": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\t// BAD: code is controlled by the user\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s); // GOOD: s is a constant string\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+      "security_severity_level": "critical"
+    },
+    "tool": {
+      "name": "CodeQL",
+      "guid": null,
+      "version": "2.23.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/codeql.yml:analyze",
+      "environment": "{\"language\":\"java\"}",
+      "category": "/language:java",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Template, which may contain code, depends on a user-provided value."
+      },
+      "location": {
+        "path": "src/main/java/com/tvm/reportrendering/service/Report.java",
+        "start_line": 85,
+        "end_line": 85,
+        "start_column": 49,
+        "end_column": 61
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/32/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 31,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/31",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/31",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2025-41242",
+      "severity": "warning",
+      "description": "org.springframework/spring-webmvc: Spring Framework MVC path traversal vulnerability",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["MEDIUM","security","vulnerability"],
+      "full_description": "Spring Framework MVC applications can be vulnerable to a “Path Traversal Vulnerability” when deployed on a non-compliant Servlet container.\n\nAn application can be vulnerable when all the following are true:\n\n  *  the application is deployed as a WAR or with an embedded Servlet container\n  *  the Servlet container  does not reject suspicious sequences https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1.html#uri-path-canonicalization \n  *  the application  serves static resources https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/static-resources.html#page-title  with Spring resource handling\n\n\nWe have verified that applications deployed on Apache Tomcat or Eclipse Jetty are not vulnerable, as long as default security features are not disabled in the configuration. Because we cannot check exploits against all Servlet containers and configuration variants, we strongly recommend upgrading your application.",
+      "help": "**Vulnerability CVE-2025-41242**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|org.springframework:spring-webmvc|6.2.10|[CVE-2025-41242](https://avd.aquasec.com/nvd/cve-2025-41242)|\n\nSpring Framework MVC applications can be vulnerable to a “Path Traversal Vulnerability” when deployed on a non-compliant Servlet container.\n\nAn application can be vulnerable when all the following are true:\n\n  *  the application is deployed as a WAR or with an embedded Servlet container\n  *  the Servlet container  does not reject suspicious sequences https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1.html#uri-path-canonicalization \n  *  the application  serves static resources https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/static-resources.html#page-title  with Spring resource handling\n\n\nWe have verified that applications deployed on Apache Tomcat or Eclipse Jetty are not vulnerable, as long as default security features are not disabled in the configuration. Because we cannot check exploits against all Servlet containers and configuration variants, we strongly recommend upgrading your application.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2025-41242",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-webmvc\nInstalled Version: 6.1.1\nVulnerability CVE-2025-41242\nSeverity: MEDIUM\nFixed Version: 6.2.10\nLink: [CVE-2025-41242](https://avd.aquasec.com/nvd/cve-2025-41242)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/31/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 30,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/30",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/30",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-38819",
+      "severity": "error",
+      "description": "org.springframework:spring-webmvc: Path traversal vulnerability in functional web frameworks",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "Applications serving static resources through the functional web frameworks WebMvc.fn or WebFlux.fn are vulnerable to path traversal attacks. An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.",
+      "help": "**Vulnerability CVE-2024-38819**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework:spring-webmvc|6.1.14|[CVE-2024-38819](https://avd.aquasec.com/nvd/cve-2024-38819)|\n\nApplications serving static resources through the functional web frameworks WebMvc.fn or WebFlux.fn are vulnerable to path traversal attacks. An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-38819",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-webmvc\nInstalled Version: 6.1.1\nVulnerability CVE-2024-38819\nSeverity: HIGH\nFixed Version: 6.1.14\nLink: [CVE-2024-38819](https://avd.aquasec.com/nvd/cve-2024-38819)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/30/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 29,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/29",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/29",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-38816",
+      "severity": "error",
+      "description": "spring-webmvc: Path Traversal Vulnerability in Spring Applications Using RouterFunctions and FileSystemResource",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "Applications serving static resources through the functional web frameworks WebMvc.fn or WebFlux.fn are vulnerable to path traversal attacks. An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.\n\nSpecifically, an application is vulnerable when both of the following are true:\n\n  *  the web application uses RouterFunctions to serve static resources\n  *  resource handling is explicitly configured with a FileSystemResource location\n\n\nHowever, malicious requests are blocked and rejected when any of the following is true:\n\n  *  the  Spring Security HTTP Firewall https://docs.spring.io/spring-security/reference/servlet/exploits/firewall.html  is in use\n  *  the application runs on Tomcat or Jetty",
+      "help": "**Vulnerability CVE-2024-38816**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework:spring-webmvc|6.1.13|[CVE-2024-38816](https://avd.aquasec.com/nvd/cve-2024-38816)|\n\nApplications serving static resources through the functional web frameworks WebMvc.fn or WebFlux.fn are vulnerable to path traversal attacks. An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.\n\nSpecifically, an application is vulnerable when both of the following are true:\n\n  *  the web application uses RouterFunctions to serve static resources\n  *  resource handling is explicitly configured with a FileSystemResource location\n\n\nHowever, malicious requests are blocked and rejected when any of the following is true:\n\n  *  the  Spring Security HTTP Firewall https://docs.spring.io/spring-security/reference/servlet/exploits/firewall.html  is in use\n  *  the application runs on Tomcat or Jetty",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-38816",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-webmvc\nInstalled Version: 6.1.1\nVulnerability CVE-2024-38816\nSeverity: HIGH\nFixed Version: 6.1.13\nLink: [CVE-2024-38816](https://avd.aquasec.com/nvd/cve-2024-38816)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/29/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 28,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/28",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/28",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2025-41234",
+      "severity": "warning",
+      "description": "springframework: Reflected download attack in Spring Framework with non-ASCII headers",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["MEDIUM","security","vulnerability"],
+      "full_description": "Description\n\nIn Spring Framework, versions 6.0.x as of 6.0.5, versions 6.1.x and 6.2.x, an application is vulnerable to a reflected file download (RFD) attack when it sets a “Content-Disposition” header with a non-ASCII charset, where the filename attribute is derived from user-supplied input.\n\nSpecifically, an application is vulnerable when all the following are true:\n\n  *  The header is prepared with org.springframework.http.ContentDisposition.\n  *  The filename is set via ContentDisposition.Builder#filename(String, Charset).\n  *  The value for the filename is derived from user-supplied input.\n  *  The application does not sanitize the user-supplied input.\n  *  The downloaded content of the response is injected with malicious commands by the attacker (see RFD paper reference for details).\n\n\nAn application is not vulnerable if any of the following is true:\n\n  *  The application does not set a “Content-Disposition” response header.\n  *  The header is not prepared with org.springframework.http.ContentDispositi",
+      "help": "**Vulnerability CVE-2025-41234**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|org.springframework:spring-web|6.2.8, 6.1.21|[CVE-2025-41234](https://avd.aquasec.com/nvd/cve-2025-41234)|\n\nDescription\n\nIn Spring Framework, versions 6.0.x as of 6.0.5, versions 6.1.x and 6.2.x, an application is vulnerable to a reflected file download (RFD) attack when it sets a “Content-Disposition” header with a non-ASCII charset, where the filename attribute is derived from user-supplied input.\n\nSpecifically, an application is vulnerable when all the following are true:\n\n  *  The header is prepared with org.springframework.http.ContentDisposition.\n  *  The filename is set via ContentDisposition.Builder#filename(String, Charset).\n  *  The value for the filename is derived from user-supplied input.\n  *  The application does not sanitize the user-supplied input.\n  *  The downloaded content of the response is injected with malicious commands by the attacker (see RFD paper reference for details).\n\n\nAn application is not vulnerable if any of the following is true:\n\n  *  The application does not set a “Content-Disposition” response header.\n  *  The header is not prepared with org.springframework.http.ContentDisposition.\n  *  The filename is set via one of:  *  ContentDisposition.Builder#filename(String), or\n  *  ContentDisposition.Builder#filename(String, ASCII)\n\n\n\n  *  The filename is not derived from user-supplied input.\n  *  The filename is derived from user-supplied input but sanitized by the application.\n  *  The attacker cannot inject malicious content in the downloaded content of the response.\n\n\nAffected Spring Products and VersionsSpring Framework:\n\n  *  6.2.0 - 6.2.7\n  *  6.1.0 - 6.1.20\n  *  6.0.5 - 6.0.28\n  *  Older, unsupported versions are not affected\n\n\nMitigationUsers of affected versions should upgrade to the corresponding fixed version.\n\nAffected version(s)Fix versionAvailability6.2.x6.2.8OSS6.1.x6.1.21OSS6.0.x6.0.29 Commercial https://enterprise.spring.io/ No further mitigation steps are necessary.\n\n\nCWE-113 in `Content-Disposition` handling in VMware Spring Framework versions 6.0.5 to 6.2.7 allows remote attackers to launch Reflected File Download (RFD) attacks via unsanitized user input in `ContentDisposition.Builder#filename(String, Charset)` with non-ASCII charsets.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2025-41234",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2025-41234\nSeverity: MEDIUM\nFixed Version: 6.2.8, 6.1.21\nLink: [CVE-2025-41234](https://avd.aquasec.com/nvd/cve-2025-41234)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/28/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 27,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/27",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/27",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-38820",
+      "severity": "warning",
+      "description": "The fix for CVE-2022-22968 made disallowedFieldspatterns in DataBinder ...",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["MEDIUM","security","vulnerability"],
+      "full_description": "The fix for CVE-2022-22968 made disallowedFields patterns in DataBinder case insensitive. However, String.toLowerCase() has some Locale dependent exceptions that could potentially result in fields not protected as expected.",
+      "help": "**Vulnerability CVE-2024-38820**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|org.springframework:spring-web|6.1.14|[CVE-2024-38820](https://avd.aquasec.com/nvd/cve-2024-38820)|\n\nThe fix for CVE-2022-22968 made disallowedFields patterns in DataBinder case insensitive. However, String.toLowerCase() has some Locale dependent exceptions that could potentially result in fields not protected as expected.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-38820",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2024-38820\nSeverity: MEDIUM\nFixed Version: 6.1.14\nLink: [CVE-2024-38820](https://avd.aquasec.com/nvd/cve-2024-38820)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/27/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 26,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/26",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/26",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-38809",
+      "severity": "warning",
+      "description": "org.springframework:spring-web: Spring Framework DoS via conditional HTTP request",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["MEDIUM","security","vulnerability"],
+      "full_description": "Applications that parse ETags from \"If-Match\" or \"If-None-Match\" request headers are vulnerable to DoS attack.\n\nUsers of affected versions should upgrade to the corresponding fixed version.\n\nUsers of older, unsupported versions could enforce a size limit on \"If-Match\" and \"If-None-Match\" headers, e.g. through a Filter.",
+      "help": "**Vulnerability CVE-2024-38809**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|org.springframework:spring-web|5.3.38, 6.0.23, 6.1.12|[CVE-2024-38809](https://avd.aquasec.com/nvd/cve-2024-38809)|\n\nApplications that parse ETags from \"If-Match\" or \"If-None-Match\" request headers are vulnerable to DoS attack.\n\nUsers of affected versions should upgrade to the corresponding fixed version.\n\nUsers of older, unsupported versions could enforce a size limit on \"If-Match\" and \"If-None-Match\" headers, e.g. through a Filter.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-38809",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2024-38809\nSeverity: MEDIUM\nFixed Version: 5.3.38, 6.0.23, 6.1.12\nLink: [CVE-2024-38809](https://avd.aquasec.com/nvd/cve-2024-38809)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/26/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 25,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/25",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/25",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-22262",
+      "severity": "error",
+      "description": "springframework: URL Parsing with Host Validation",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "Applications that use UriComponentsBuilder to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.\n\nThis is the same as  CVE-2024-22259 https://spring.io/security/cve-2024-22259  and  CVE-2024-22243 https://spring.io/security/cve-2024-22243 , but with different input.",
+      "help": "**Vulnerability CVE-2024-22262**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework:spring-web|5.3.34, 6.0.19, 6.1.6|[CVE-2024-22262](https://avd.aquasec.com/nvd/cve-2024-22262)|\n\nApplications that use UriComponentsBuilder to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.\n\nThis is the same as  CVE-2024-22259 https://spring.io/security/cve-2024-22259  and  CVE-2024-22243 https://spring.io/security/cve-2024-22243 , but with different input.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-22262",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2024-22262\nSeverity: HIGH\nFixed Version: 5.3.34, 6.0.19, 6.1.6\nLink: [CVE-2024-22262](https://avd.aquasec.com/nvd/cve-2024-22262)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/25/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 24,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/24",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/24",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-22259",
+      "severity": "error",
+      "description": "springframework: URL Parsing with Host Validation",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "Applications that use UriComponentsBuilder in Spring Framework to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.\n\nThis is the same as  CVE-2024-22243 https://spring.io/security/cve-2024-22243 , but with different input.",
+      "help": "**Vulnerability CVE-2024-22259**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework:spring-web|6.1.5, 6.0.18, 5.3.33|[CVE-2024-22259](https://avd.aquasec.com/nvd/cve-2024-22259)|\n\nApplications that use UriComponentsBuilder in Spring Framework to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.\n\nThis is the same as  CVE-2024-22243 https://spring.io/security/cve-2024-22243 , but with different input.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-22259",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2024-22259\nSeverity: HIGH\nFixed Version: 6.1.5, 6.0.18, 5.3.33\nLink: [CVE-2024-22259](https://avd.aquasec.com/nvd/cve-2024-22259)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/24/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 23,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/23",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/23",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-22243",
+      "severity": "error",
+      "description": "springframework: URL Parsing with Host Validation",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "Applications that use UriComponentsBuilder to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.",
+      "help": "**Vulnerability CVE-2024-22243**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework:spring-web|6.1.4, 6.0.17, 5.3.32|[CVE-2024-22243](https://avd.aquasec.com/nvd/cve-2024-22243)|\n\nApplications that use UriComponentsBuilder to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a  open redirect https://cwe.mitre.org/data/definitions/601.html  attack or to a SSRF attack if the URL is used after passing validation checks.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-22243",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-web\nInstalled Version: 6.1.1\nVulnerability CVE-2024-22243\nSeverity: HIGH\nFixed Version: 6.1.4, 6.0.17, 5.3.32\nLink: [CVE-2024-22243](https://avd.aquasec.com/nvd/cve-2024-22243)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/23/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 22,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/22",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/22",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2025-22233",
+      "severity": "note",
+      "description": "CVE-2024-38820 ensured Locale-independent, lowercase conversion for bo ...",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["LOW","security","vulnerability"],
+      "full_description": "CVE-2024-38820 ensured Locale-independent, lowercase conversion for both the configured disallowedFields patterns and for request parameter names. However, there are still cases where it is possible to bypass the disallowedFields checks.\n\nAffected Spring Products and Versions\n\nSpring Framework:\n  *  6.2.0 - 6.2.6\n\n  *  6.1.0 - 6.1.19\n\n  *  6.0.0 - 6.0.27\n\n  *  5.3.0 - 5.3.42\n  *  Older, unsupported versions are also affected\n\n\n\nMitigation\n\nUsers of affected versions should upgrade to the corresponding fixed version.\n\nAffected version(s)Fix Version Availability 6.2.x\n 6.2.7\nOSS6.1.x\n 6.1.20\nOSS6.0.x\n 6.0.28\n Commercial https://enterprise.spring.io/ 5.3.x\n 5.3.43\n Commercial https://enterprise.spring.io/ \nNo further mitigation steps are necessary.\n\n\nGenerally, we recommend using a dedicated model object with properties only for data binding, or using constructor binding since constructor arguments explicitly declare what to bind together with turning off setter binding through the declarativeBinding flag. See t",
+      "help": "**Vulnerability CVE-2025-22233**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|LOW|org.springframework:spring-context|6.2.7, 6.1.20|[CVE-2025-22233](https://avd.aquasec.com/nvd/cve-2025-22233)|\n\nCVE-2024-38820 ensured Locale-independent, lowercase conversion for both the configured disallowedFields patterns and for request parameter names. However, there are still cases where it is possible to bypass the disallowedFields checks.\n\nAffected Spring Products and Versions\n\nSpring Framework:\n  *  6.2.0 - 6.2.6\n\n  *  6.1.0 - 6.1.19\n\n  *  6.0.0 - 6.0.27\n\n  *  5.3.0 - 5.3.42\n  *  Older, unsupported versions are also affected\n\n\n\nMitigation\n\nUsers of affected versions should upgrade to the corresponding fixed version.\n\nAffected version(s)Fix Version Availability 6.2.x\n 6.2.7\nOSS6.1.x\n 6.1.20\nOSS6.0.x\n 6.0.28\n Commercial https://enterprise.spring.io/ 5.3.x\n 5.3.43\n Commercial https://enterprise.spring.io/ \nNo further mitigation steps are necessary.\n\n\nGenerally, we recommend using a dedicated model object with properties only for data binding, or using constructor binding since constructor arguments explicitly declare what to bind together with turning off setter binding through the declarativeBinding flag. See the Model Design section in the reference documentation.\n\nFor setting binding, prefer the use of allowedFields (an explicit list) over disallowedFields.\n\nCredit\n\nThis issue was responsibly reported by the TERASOLUNA Framework Development Team from NTT DATA Group Corporation.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2025-22233",
+      "security_severity_level": "low"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-context\nInstalled Version: 6.1.1\nVulnerability CVE-2025-22233\nSeverity: LOW\nFixed Version: 6.2.7, 6.1.20\nLink: [CVE-2025-22233](https://avd.aquasec.com/nvd/cve-2025-22233)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/22/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 21,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/21",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/21",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2024-38820",
+      "severity": "warning",
+      "description": "The fix for CVE-2022-22968 made disallowedFieldspatterns in DataBinder ...",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["MEDIUM","security","vulnerability"],
+      "full_description": "The fix for CVE-2022-22968 made disallowedFields patterns in DataBinder case insensitive. However, String.toLowerCase() has some Locale dependent exceptions that could potentially result in fields not protected as expected.",
+      "help": "**Vulnerability CVE-2024-38820**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|org.springframework:spring-web|6.1.14|[CVE-2024-38820](https://avd.aquasec.com/nvd/cve-2024-38820)|\n\nThe fix for CVE-2022-22968 made disallowedFields patterns in DataBinder case insensitive. However, String.toLowerCase() has some Locale dependent exceptions that could potentially result in fields not protected as expected.",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2024-38820",
+      "security_severity_level": "medium"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework:spring-context\nInstalled Version: 6.1.1\nVulnerability CVE-2024-38820\nSeverity: MEDIUM\nFixed Version: 6.1.14\nLink: [CVE-2024-38820](https://avd.aquasec.com/nvd/cve-2024-38820)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/21/instances",
+    "dismissal_approved_by": null
+  },
+  {
+    "number": 20,
+    "created_at": "2025-09-16T12:50:09Z",
+    "updated_at": "2025-09-16T12:53:15Z",
+    "url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/20",
+    "html_url": "https://github.com/FreeSideNomad/report-rendering-api/security/code-scanning/20",
+    "assignees": [
+
+    ],
+    "state": "open",
+    "fixed_at": null,
+    "dismissed_by": null,
+    "dismissed_at": null,
+    "dismissed_reason": null,
+    "dismissed_comment": null,
+    "rule": {
+      "id": "CVE-2025-22235",
+      "severity": "error",
+      "description": "org.springframework.boot/spring-boot: Spring Boot EndpointRequest.to() creates wrong matcher if actuator endpoint is not exposed",
+      "name": "LanguageSpecificPackageVulnerability",
+      "tags": ["HIGH","security","vulnerability"],
+      "full_description": "EndpointRequest.to() creates a matcher for null/** if the actuator endpoint, for which the EndpointRequest has been created, is disabled or not exposed.\n\nYour application may be affected by this if all the following conditions are met:\n\n  *  You use Spring Security\n  *  EndpointRequest.to() has been used in a Spring Security chain configuration\n  *  The endpoint which EndpointRequest references is disabled or not exposed via web\n  *  Your application handles requests to /null and this path needs protection\n\n\nYou are not affected if any of the following is true:\n\n  *  You don't use Spring Security\n  *  You don't use EndpointRequest.to()\n  *  The endpoint which EndpointRequest.to() refers to is enabled and is exposed\n  *  Your application does not handle requests to /null or this path does not need protection",
+      "help": "**Vulnerability CVE-2025-22235**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|org.springframework.boot:spring-boot|3.3.11, 3.4.5|[CVE-2025-22235](https://avd.aquasec.com/nvd/cve-2025-22235)|\n\nEndpointRequest.to() creates a matcher for null/** if the actuator endpoint, for which the EndpointRequest has been created, is disabled or not exposed.\n\nYour application may be affected by this if all the following conditions are met:\n\n  *  You use Spring Security\n  *  EndpointRequest.to() has been used in a Spring Security chain configuration\n  *  The endpoint which EndpointRequest references is disabled or not exposed via web\n  *  Your application handles requests to /null and this path needs protection\n\n\nYou are not affected if any of the following is true:\n\n  *  You don't use Spring Security\n  *  You don't use EndpointRequest.to()\n  *  The endpoint which EndpointRequest.to() refers to is enabled and is exposed\n  *  Your application does not handle requests to /null or this path does not need protection",
+      "help_uri": "https://avd.aquasec.com/nvd/cve-2025-22235",
+      "security_severity_level": "high"
+    },
+    "tool": {
+      "name": "Trivy",
+      "guid": null,
+      "version": "0.65.0"
+    },
+    "most_recent_instance": {
+      "ref": "refs/heads/main",
+      "analysis_key": ".github/workflows/security.yml:trivy-scan",
+      "environment": "{}",
+      "category": ".github/workflows/security.yml:trivy-scan",
+      "state": "open",
+      "commit_sha": "fc903d1d44549805c991bc4dbe7379cd3d1b12f2",
+      "message": {
+        "text": "Package: org.springframework.boot:spring-boot\nInstalled Version: 3.2.0\nVulnerability CVE-2025-22235\nSeverity: HIGH\nFixed Version: 3.3.11, 3.4.5\nLink: [CVE-2025-22235](https://avd.aquasec.com/nvd/cve-2025-22235)"
+      },
+      "location": {
+        "path": "pom.xml",
+        "start_line": 1,
+        "end_line": 1,
+        "start_column": 1,
+        "end_column": 1
+      },
+      "classifications": []
+    },
+    "instances_url": "https://api.github.com/repos/FreeSideNomad/report-rendering-api/code-scanning/alerts/20/instances",
+    "dismissal_approved_by": null
+  }
+]


### PR DESCRIPTION
- Remove duplicate private sanitizeForLogging methods from all classes
- Consolidate log sanitization into single SecurityUtils utility
- Add SecurityUtils class with centralized sanitization logic
- Improve code maintainability and consistency

🤖 Generated with [Claude Code](https://claude.ai/code)